### PR TITLE
Add a Windows build script and fix some asm

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,40 @@
+@echo off
+rem PS4 Payload SDK libPS4 build script... for Windows!
+rem written by nik...
+
+setlocal EnableDelayedExpansion
+
+rem set this to your C compiler toolchain executable
+set CC=clang
+rem set this to your ar toolchain executable
+set AR=llvm-ar
+
+rem usually you do not need to touch the rest of this:
+set RDIR=libPS4
+set ODIR=build
+set SDIR=source
+set IDIR=include
+set CFLAGS=--target=x86_64-pc-freebsd12-elf -Wno-unused-command-line-argument -I"%IDIR%" -Os -std=c11 -ffunction-sections -fdata-sections -fno-builtin -nostartfiles -nostdlib -Wall -Wextra -masm=intel -march=btver2 -mtune=btver2 -m64 -mabi=sysv -mcmodel=small -fpie -fPIC
+set TARGET=%RDIR%.a
+set OBJS=
+
+
+pushd %RDIR%
+
+rem clean
+rmdir /s /q %ODIR%
+del /q /f %TARGET%
+mkdir %ODIR%
+
+rem do the build
+for %%f in (%SDIR%\*.c %SDIR%\*.s) do (
+	%CC% -c -o %ODIR%\%%~nf.o %%f %CFLAGS%
+)
+
+for %%f in (%ODIR%\*.o) do set OBJS=!OBJS! %%f
+
+%AR% rcs %TARGET% %OBJS%
+
+popd
+
+echo Done

--- a/libPS4/include/payload_utils.h
+++ b/libPS4/include/payload_utils.h
@@ -112,7 +112,7 @@ static inline __attribute__((always_inline)) uint64_t __readmsr(unsigned long __
 static inline __attribute__((always_inline)) uint64_t readCr0(void) {
   uint64_t cr0;
   __asm__ volatile(".intel_syntax noprefix\n\n"
-                   "mov cr0, %0"
+                   "mov %0, cr0"
                    : "=r"(cr0)
                    :
                    : "memory");
@@ -121,7 +121,7 @@ static inline __attribute__((always_inline)) uint64_t readCr0(void) {
 
 static inline __attribute__((always_inline)) void writeCr0(uint64_t cr0) {
   __asm__ volatile(".intel_syntax noprefix\n\n"
-                   "mov %0, cr0"
+                   "mov cr0, %0"
                    :
                    : "r"(cr0)
                    : "memory");

--- a/libPS4/include/payload_utils.h
+++ b/libPS4/include/payload_utils.h
@@ -102,15 +102,17 @@ struct kpayload_target_id_args {
 static inline __attribute__((always_inline)) uint64_t __readmsr(unsigned long __register) {
   unsigned long __edx;
   unsigned long __eax;
-  __asm__("rdmsr"
-          : "=d"(__edx), "=a"(__eax)
-          : "c"(__register));
-  return (((uint64_t)__edx) << 32) | (uint64_t)__eax;
+  __asm__ volatile(".intel_syntax noprefix\n\n"
+                   "rdmsr"
+                   : "=d"(__edx), "=a"(__eax)
+                   : "c"(__register));
+  return (((uint64_t)__edx) << 32U) | ((uint64_t)__eax);
 }
 
 static inline __attribute__((always_inline)) uint64_t readCr0(void) {
   uint64_t cr0;
-  __asm__ volatile("movq %0, %%cr0"
+  __asm__ volatile(".intel_syntax noprefix\n\n"
+                   "mov cr0, %0"
                    : "=r"(cr0)
                    :
                    : "memory");
@@ -118,7 +120,8 @@ static inline __attribute__((always_inline)) uint64_t readCr0(void) {
 }
 
 static inline __attribute__((always_inline)) void writeCr0(uint64_t cr0) {
-  __asm__ volatile("movq %%cr0, %0"
+  __asm__ volatile(".intel_syntax noprefix\n\n"
+                   "mov %0, cr0"
                    :
                    : "r"(cr0)
                    : "memory");

--- a/libPS4/include/syscall.h
+++ b/libPS4/include/syscall.h
@@ -6,11 +6,7 @@
 #include "types.h"
 
 #define SYSCALL(name, number)        \
-  __asm__(".intel_syntax noprefix"); \
-  __asm__(".globl " #name "");       \
-  __asm__("" #name ":");             \
-  __asm__("movq rax, " #number "");  \
-  __asm__("jmp syscall_macro");
+  __asm__ (".intel_syntax noprefix\n\n" ".globl " #name "\n" #name ":\n" "mov rax, " #number "\n" "jmp syscall_macro\n")
 
 unsigned long syscall(unsigned long n, ...);
 

--- a/libPS4/source/syscall.s
+++ b/libPS4/source/syscall.s
@@ -22,8 +22,8 @@ _error:
 	call __error[rip]
 	pop rcx
 	mov [rax], ecx
-	movq rax, -1
-	movq rdx, -1
+	mov rax, -1
+	mov rdx, -1
 
 _end:
 	ret


### PR DESCRIPTION
Intel syntax does not support `movq`, because in Intel syntax there's no need to specify size suffixes, just `mov` is sufficient and the assembler *should* deduce the size of the operation from the operand.

Also rdmsr didn't have it's asm statement marked as volatile (which it should be).

Do not merge now since I'm figuring out why it's broken...