### PR TITLE
add support for Arch and Fedora

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,48 @@
 #!/bin/bash
 
-# DEPRECIATED: Left for example on how you *could* install it
+# Function to install prerequisites for Debian-based systems (including Ubuntu)
+install_debian() {
+  apt-get update
+  apt-get -y install binutils gcc make
+}
 
-# Install prerequisites if root
+# Function to install prerequisites for Fedora
+install_fedora() {
+  dnf install -y binutils binutils-gold gcc make
+}
+
+# Function to install prerequisites for Arch
+install_arch() {
+  pacman -Sy --noconfirm binutils gcc make
+}
+
+# Detect the distribution
 if [ "$EUID" -ne 0 ]; then
   echo "Not root, skipping update and install"
   exit
+fi
+
+# Check for various distributions
+if [ -f /etc/os-release ]; then
+  . /etc/os-release
+  case "$ID" in
+    ubuntu|debian)
+      install_debian
+      ;;
+    fedora)
+      install_fedora
+      ;;
+    arch)
+      install_arch
+      ;;
+    *)
+      echo "Unsupported distribution: $ID"
+      exit 1
+      ;;
+  esac
 else
-  apt-get update
-  apt-get install -y --no-install-recommends binutils gcc make
+  echo "Unsupported distribution"
+  exit 1
 fi
 
 # Delete directory if it exists and make empty directory


### PR DESCRIPTION
Hi i have modify the install.sh to add support for Arch and Fedora.

A little note for Fedora: by using binutils compiled payloads are corrupted/not working so to make the payloads compile on Fedora we need to use binutils-gold, that mean modify all makefile of the payloads to use "-fuse-ld=gold" so not sure if you really want to support Fedora officially. (i am maybe saying shit here but i wasn't able to compile a payload by using binutils on Fedora so yeah idk lol)