### PR TITLE
Make `file_exists` `const`

### DIFF
--- a/libPS4/include/file.h
+++ b/libPS4/include/file.h
@@ -87,7 +87,7 @@ int lstat(const char *path, struct stat *buf);
 int getdents(int fd, char *buf, int count);
 off_t lseek(int fildes, off_t offset, int whence);
 int getSandboxDirectory(char *destination, int *length);
-int file_exists(char *fname);
+int file_exists(const char *fname);
 int dir_exists(char *dname);
 int symlink_exists(const char *fname);
 void touch_file(char *destfile);

--- a/libPS4/source/file.c
+++ b/libPS4/source/file.c
@@ -30,7 +30,7 @@ int getSandboxDirectory(char *destination, int *length) {
   return syscall(602, 0, destination, length);
 }
 
-int file_exists(char *fname) {
+int file_exists(const char *fname) {
   int file = open(fname, O_RDONLY, 0);
   if (file != -1) {
     close(file);


### PR DESCRIPTION
```
source/common.c: In function ‘write_blob’:
source/common.c:14:19: warning: passing argument 1 of ‘file_exists’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   14 |   if (file_exists(path)) {
      |                   ^~~~
In file included from /lib/ps4-payload-sdk/libPS4/include/ps4.h:14,
                 from source/common.c:1:
/lib/ps4-payload-sdk/libPS4/include/file.h:90:23: note: expected ‘char *’ but argument is of type ‘const char *’
   90 | int file_exists(char *fname);
      |                 ~~~~~~^~~~~
```