### PR TITLE
add `build-essential` for some debian systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ if [ "$EUID" -ne 0 ]; then
   exit
 else
   apt-get update
-  apt-get install -y --no-install-recommends binutils gcc make
+  apt-get install -y --no-install-recommends build-essential binutils gcc make
 fi
 
 # Delete directory if it exists and make empty directory


### PR DESCRIPTION
```
gcc -c -o build/barrier.o source/barrier.c -Iinclude -Os -std=c11 -ffunction-sections -fdata-sections -fno-builtin -nostartfiles -nostdlib -Wall -Wextra -masm=intel -march=btver2 -mtune=btver2 -m64 -mabi=sysv -mcmodel=small -fpie -fPIC
In file included from include/types.h:6,
                 from include/syscall.h:6,
                 from source/barrier.c:1:
/usr/lib/gcc/x86_64-linux-gnu/14/include/stdint.h:9:16: fatal error: stdint.h: No such file or directory
    9 | # include_next <stdint.h>
      |                ^~~~~~~~~~
compilation terminated.
make: *** [Makefile:17: build/barrier.o] Error 1
```
